### PR TITLE
NOTICKET Adjust Ryuk setup time within build

### DIFF
--- a/appstore-metadata-service/pom.xml
+++ b/appstore-metadata-service/pom.xml
@@ -156,25 +156,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>com.lgi.common.maven</groupId>
-                <artifactId>tcp-msg-maven-plugin</artifactId>
-                <version>0.0.1-SNAPSHOT</version>
-                <executions>
-                    <execution>
-                        <id>write-death-note-for-postgres</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>tcpmsg</goal>
-                        </goals>
-                        <configuration>
-                            <port>${ryuk.port}</port>
-                            <msg>label=killme</msg>
-                            <repeatAmount>2</repeatAmount>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
                 <version>0.34.0</version>
@@ -225,6 +206,25 @@
                         <goals>
                             <goal>start</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.lgi.common.maven</groupId>
+                <artifactId>tcp-msg-maven-plugin</artifactId>
+                <version>0.0.1-SNAPSHOT</version>
+                <executions>
+                    <execution>
+                        <id>write-death-note-for-postgres</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>tcpmsg</goal>
+                        </goals>
+                        <configuration>
+                            <port>${ryuk.port}</port>
+                            <msg>label=killme</msg>
+                            <repeatAmount>2</repeatAmount>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
Recent change for Ryuk provisioning attempts from 6 to 2 were not successful on master. 

```
[INFO] maven-tcpmsg: Attempting [0] to send message 'label=killme' to TCP socket on localhost:46577
[WARNING] maven-tcpmsg: Issue with connection to TCP socket on localhost:46577 - ConnectException: Connection refused (Connection refused)
[INFO] DOCKER> Pulling from library/postgres
[INFO] maven-tcpmsg: Attempting [1] to send message 'label=killme' to TCP socket on localhost:46577
[WARNING] maven-tcpmsg: Issue with connection to TCP socket on localhost:46577 - ConnectException: Connection refused (Connection refused)
[INFO] DOCKER> Digest: sha256:f1000a642e125c2d84c537c0cccc4d049b05dd6a744c6f6b2e0f82503763352a
[INFO] DOCKER> Status: Downloaded newer image for postgres:11
[INFO] DOCKER> Pulled postgres:11 in 7 seconds 
[INFO] DOCKER> [testcontainers/ryuk:0.3.0] "ryuk-summoned": Start container f1fbf5415a43
[INFO] DOCKER> [postgres:11] "postgres": Start container 06488c1a7186
[INFO] DOCKER> [postgres:11] "postgres": Pausing for 5000 ms
[INFO] 
```
Both attempts to wriete a deathnote were executed before `maven-docker-pluging` even summoned `ryuk`...
Increased `repeatAmount` to `4` didn't work too...
Moved provisioning part after containers start within `generate-sources` phase because time or downloading images varied significantly for each build.