### PR TITLE
SPARK-29296 Build application jar with dependencies

### DIFF
--- a/appstore-metadata-service/README.md
+++ b/appstore-metadata-service/README.md
@@ -13,10 +13,11 @@ Then execute to package it:
 mvn package
 ```
 
-Then to run it you need to:
+Then to run it you need to be in `target` directory:
 
 ```
-java -jar target/appstore-metadata-service-0.0.1-SNAPSHOT.jar
+cd target
+java -jar appstore-metadata-service-0.0.1-SNAPSHOT.jar
 ```
 
 The service is available by default at:

--- a/appstore-metadata-service/docker-compose/asms/Dockerfile
+++ b/appstore-metadata-service/docker-compose/asms/Dockerfile
@@ -16,6 +16,9 @@
 #  and limitations under the License.
 
 FROM adoptopenjdk/openjdk13:alpine-jre
-ARG JAR_FILE=target/*.jar
+ARG JAR_FILE=target/appstore-metadata-service.jar
+RUN mkdir jars
 COPY ${JAR_FILE} app.jar
+COPY target/jars jars/
+
 ENTRYPOINT ["java","-jar","/app.jar"]

--- a/appstore-metadata-service/pom.xml
+++ b/appstore-metadata-service/pom.xml
@@ -110,9 +110,11 @@
             <artifactId>jackson-core</artifactId>
             <version>2.11.1</version>
         </dependency>
+
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -142,19 +144,44 @@
         </resources>
         <plugins>
             <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>copy-dependencies</id>
+                        <phase>prepare-package</phase>
                         <goals>
-                            <goal>repackage</goal>
+                            <goal>copy-dependencies</goal>
                         </goals>
                         <configuration>
-                            <attach>false</attach>
+                            <outputDirectory>${project.build.directory}/jars</outputDirectory>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>false</overWriteSnapshots>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                            <includeScope>runtime</includeScope>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <classpathPrefix>jars/</classpathPrefix>
+                            <mainClass>com.lgi.appstore.metadata.Application</mainClass>
+                        </manifest>
+                        <manifestEntries>
+                            <Class-Path>.</Class-Path>
+                        </manifestEntries>
+                    </archive>
+
+                    <finalName>${project.artifactId}</finalName>
+                </configuration>
+            </plugin>
+
             <plugin>
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Changes:
- create application as jar with dependencies stored in 'jars' folder.

![Screenshot 2020-12-08 at 12 26 53](https://user-images.githubusercontent.com/862563/101478337-d04ff500-3950-11eb-887e-fb645a5e21e5.png)

![Screenshot 2020-12-08 at 12 27 22](https://user-images.githubusercontent.com/862563/101478348-d5ad3f80-3950-11eb-84e9-4bc8aced074b.png)
